### PR TITLE
Remove caching from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,13 +19,6 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-      - name: Cache Packages
-        uses: actions/cache@v1
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - name: Strip SNAPSHOT Version
         run: |
           mvn $MAVEN_CLI_OPTS \


### PR DESCRIPTION
Caching is only supported on PRs and merges

Signed-off-by: Trevor Bramwell <tbramwell@linuxfoundation.org>