### PR TITLE
New CI

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -8,7 +8,7 @@ on:
       - master
 
 jobs:
-  build:
+  merge:
     runs-on: ubuntu-latest
     env:
       MAVEN_CLI_OPTS: "-s .m2/settings.xml --batch-mode"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
       - created
 
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
     env:
       MAVEN_CLI_OPTS: "-s .m2/settings.xml --batch-mode"

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,3 @@
-target/
-pom.xml.tag
-pom.xml.releaseBackup
-pom.xml.versionsBackup
-pom.xml.next
-release.properties
-dependency-reduced-pom.xml
-buildNumber.properties
-.mvn/timing.properties
-.mvn/wrapper/maven-wrapper.jar
+.tox/
+*.retry
 *.swp

--- a/PULL_REQUEST_TEXT
+++ b/PULL_REQUEST_TEXT
@@ -1,0 +1,56 @@
+# My CI/CD Ready Repo
+
+## Roles can be installed with:
+
+  # Future this will be `install linuxfoundation.ci`
+  #  which will contain all the other roles as dependencies
+  #  and may be done as a post-run script for cookiecutter
+  ansible-galaxy install -r requirements.yml --roles-path roles
+
+## Individual roles can be tested with the following command:
+
+  # In the future this will be molecule, or an ansible specific runner
+  docker run --rm -it \
+  -v $PWD:/app \
+  -w /app \
+  -e ANSIBLE_STDOUT_CALLBACK=unixy \
+  -e WORKSPACE=/app \
+  williamyeh/ansible:alpine3 \
+  ansible-playbook -c local .playbooks/verify.yml
+
+
+
+
+
+# Java Toolchain
+
+## Environment
+
+- MAVEN_RELEASE_REPO_URL
+  URL of the release repository
+
+- MAVEN_RELEASE_REPO_USER
+  Username for the release repository
+
+- MAVEN_RELEASE_REPO_PASS
+  Password for the release repository
+
+- MAVEN_RELEASE_REPO
+  Nmae of the release repository
+
+- MAVEN_SNAPSHOT_REPO_URL
+  URL of the snapshot repository
+
+- MAVEN_SNAPSHOT_REPO_USER
+  Username for the snapshot repository
+
+- MAVEN_SNAPSHOT_REPO_PASS
+  Password for the snapshot repository
+
+- MAVEN_SNAPSHOT_REPO
+  Nmae of the snapshot repository
+
+
+
+
+


### PR DESCRIPTION
Add new CI please!
# My CI/CD Ready Repo

## Roles can be installed with:

  # Future this will be `install linuxfoundation.ci`
  #  which will contain all the other roles as dependencies
  #  and may be done as a post-run script for cookiecutter
  ansible-galaxy install -r requirements.yml --roles-path roles

## Individual roles can be tested with the following command:

  # In the future this will be molecule, or an ansible specific runner
  docker run --rm -it \
  -v $PWD:/app \
  -w /app \
  -e ANSIBLE_STDOUT_CALLBACK=unixy \
  -e WORKSPACE=/app \
  williamyeh/ansible:alpine3 \
  ansible-playbook -c local .playbooks/verify.yml





# Java Toolchain

## Environment

- MAVEN_RELEASE_REPO_URL
  URL of the release repository

- MAVEN_RELEASE_REPO_USER
  Username for the release repository

- MAVEN_RELEASE_REPO_PASS
  Password for the release repository

- MAVEN_RELEASE_REPO
  Nmae of the release repository

- MAVEN_SNAPSHOT_REPO_URL
  URL of the snapshot repository

- MAVEN_SNAPSHOT_REPO_USER
  Username for the snapshot repository

- MAVEN_SNAPSHOT_REPO_PASS
  Password for the snapshot repository

- MAVEN_SNAPSHOT_REPO
  Nmae of the snapshot repository






Signed-off-by: ITX CI \<itx@linuxfoundation.org\>
on-behalf-of: @linuxfoundation-it \<itx@linuxfoundation.org\>